### PR TITLE
TeleOp and Abstract Hardware Class

### DIFF
--- a/Hardware.java
+++ b/Hardware.java
@@ -1,0 +1,24 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.DcMotor;
+
+/**
+ * The Hardware class initializes various hardware components and variables as
+ * well as condensing various processes into specific methods.
+ */
+@TeleOp (name = "TeleOp V1")
+public abstract class Hardware extends LinearOpMode{
+
+    DcMotor frontLeft;
+
+    /**
+     * Maps the hardware of every component in the robot.
+     */
+    public void hardwareMap()
+    {
+        frontLeft = hardwareMap.get(DcMotor.class, "fl");
+    }
+
+}

--- a/TeleOp.java
+++ b/TeleOp.java
@@ -1,0 +1,29 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+
+/**
+ * The TeleOp class extends the Hardware class to inherit various
+ * methods and initialized hardware components specific to the
+ * hardware of the robot.
+ */
+@
+public class TeleOp extends Hardware {
+
+        @Override
+        public void runOpMode() throws InterruptedException {
+
+            hardwareMap();
+
+            double frPower, flPower, rrPower, rlPower = 0;
+
+            while (opModeIsActive()) {
+                //Mecanum Drive
+                frPower = -gamepad1.left_stick_y - gamepad1.right_stick_x - gamepad1.left_stick_x;
+                flPower = -gamepad1.left_stick_y + gamepad1.right_stick_x + gamepad1.left_stick_x;
+                rrPower = -gamepad1.left_stick_y - gamepad1.right_stick_x + gamepad1.left_stick_x;
+                rlPower = -gamepad1.left_stick_y + gamepad1.right_stick_x - gamepad1.left_stick_x;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The abstract hardware class extends linear op mode but because its abstract it doesn't need to include the runOpMode() method. The TeleOp class extends the Hardware class and inherits all initialized hardware components and methods. This makes it so you don't have to initialize a hardware object and use dot notation, it just inherits everything.